### PR TITLE
Bugfixes and mass download functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,7 @@ fabric.properties
 .idea/**/azureSettings.xml
 
 # End of https://www.toptal.com/developers/gitignore/api/node,webstorm
+
+videos/*.mkv
+videos/keys/*.json
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -24,7 +24,21 @@ if (!fs.existsSync(videoPath)) {
 }
 
 
+//enter the npo start show name and download all episodes from all seasons.
+//second parameter = season count (0 = all)
+//third parameter = reverse seasons (false = Start from latest, true = Start from first)
 
+getAllEpisodesFromShow("keuringsdienst-van-waarde", 2, true).then((urls) => {
+    getEpisodes(urls);
+});
+
+
+// enter the npo start show name and download all episodes from the chosen season.
+/*
+getAllEpisodesFromSeason("keuringsdienst-van-waarde", "seizoen-3").then((urls) => {
+    getEpisodes(urls);
+});
+*/
 
 /*
 enter the video id here, you can find it in the url of the video, full url should look like this: https://www.npostart.nl/AT_300003151
@@ -35,9 +49,9 @@ if the video ids are sequential you can use the second parameter to download mul
 //     console.log(result);
 // });
 
-getEpisode("https://npo.nl/start/serie/flikken-maastricht/seizoen-11/undercover_1/afspelen").then((result) => {
-    console.log(result);
-});
+//getEpisode("https://npo.nl/start/serie/flikken-maastricht/seizoen-11/undercover_1/afspelen").then((result) => {
+//    console.log(result);
+//});
 
 let browser;
 
@@ -51,18 +65,22 @@ async function npoLogin() {
     await page.waitForSelector('div[data-testid=\'btn-login\']');
     await page.click('div[data-testid=\'btn-login\']');
 
-
     await page.waitForSelector('#EmailAddress');
     await page.$eval('#EmailAddress', (el, secret) => el.value = secret, email);
     await page.$eval('#Password', (el, secret) => el.value = secret, password);
 
+    await sleep(1000);
     await page.waitForSelector('button[value=\'login\']');
     await page.click('button[value=\'login\']');
 
     await page.waitForSelector('button[class=\'group w-full cursor-pointer\']');
     await page.click('button[class=\'group w-full cursor-pointer\']');
 
-    await page.waitForNetworkIdle();
+    try {
+        await page.waitForNetworkIdle();
+    } catch (TimeoutError) {
+        // keep going
+    }
 
     await page.close();
 
@@ -93,6 +111,82 @@ async function getEpisodesInOrder(firstId, episodeCount) {
     return getEpisodes(urls)
 }
 
+async function getAllEpisodesFromShow(show, seasonCount=0, reverse=false) {
+    browser = await puppeteer.launch({headless: false});
+    const page = await browser.newPage();
+
+    const urls = [];
+
+    await page.goto(`https://npo.nl/start/serie/${show}`);
+
+    const jsonData = await page.evaluate(() => {
+        return JSON.parse(document.getElementById('__NEXT_DATA__').innerText) || null;
+    });
+    
+    if (jsonData === null) {
+        console.log('Error retrieving show data');
+        return null;
+    }
+
+    await page.close();
+    await browser.close();
+
+    const seasons = reverse 
+    ? jsonData['props']['pageProps']['dehydratedState']['queries'][1]['state']['data'].reverse() 
+    : jsonData['props']['pageProps']['dehydratedState']['queries'][1]['state']['data'];
+
+    const seasonsLength = seasonCount !== 0 ? seasonCount : seasons.length;
+
+
+    for (var i = 0; i < seasonsLength; i++){
+        let season = seasons[i]['slug'];
+        console.log(season);
+        let seasonUrls = await getAllEpisodesFromSeason(show, season, reverse);
+        for (var x = 0; x < seasonUrls.length; x++) {
+            console.log(seasonUrls[x]);
+            urls.push(seasonUrls[x]);
+        }
+    }
+
+    return urls;
+}
+
+async function getAllEpisodesFromSeason(show, season=0, reverse=false) {
+    browser = await puppeteer.launch({headless: false});
+    const page = await browser.newPage();
+
+    const urls = [];
+
+    console.log(`${show} - ${season}`);
+
+    await page.goto(`https://npo.nl/start/serie/${show}/${season}`);
+    await page.waitForSelector('div[data-testid=\'btn-login\']');
+    const jsonData = await page.evaluate(() => {
+        return JSON.parse(document.getElementById('__NEXT_DATA__').innerText) || null;
+    });
+
+    if (jsonData === null) {
+        console.log('Error retrieving episode data');
+        return null;
+    }
+
+    const episodes = reverse
+    ? jsonData['props']['pageProps']['dehydratedState']['queries'][2]['state']['data'].reverse()
+    : jsonData['props']['pageProps']['dehydratedState']['queries'][2]['state']['data'];
+
+    for (var x = 0; x < episodes.length; x++){
+        let programKey = episodes[x]['programKey'];
+        let slug = episodes[x]['slug'];
+        let productId = episodes[x]['productId'];
+        console.log(`ep. ${programKey} - ${slug} - ${productId}`);
+        urls.push(`https://npo.nl/start/serie/${show}/${season}/${slug}/afspelen`);
+    }
+
+    await page.close();
+    await browser.close();
+
+    return urls;
+}
 
 
 async function getEpisodes(urls) {
@@ -101,10 +195,9 @@ async function getEpisodes(urls) {
     await promiseLogin;
     for (const npo_url of urls) {
         informationList.push(getInformation(npo_url));
-        await sleep(5000);
+        await sleep(7500);
     }
 
-    console.log('test');
     const list = await Promise.all(informationList);
     await browser.close();
 
@@ -128,65 +221,97 @@ async function downloadMulti(InformationList, runParallel = false) {
 }
 
 async function getInformation(url) {
-    const page = await browser.newPage();
+    let tries = 0;
+    while(tries <= 3) {
+        tries++;
+        try {
+            const page = await browser.newPage();
 
-    await page.goto(url);
-    // const iframe = await page.waitForSelector(`#iframe-${id}`);
-    await page.waitForSelector(`.bmpui-image`);
-    const filename = await generateFileName(page);
+            await page.goto(url);
+            if(page.url() === "https://npo.nl/start") {
+                await page.close();
+                console.log(`Error wrong episode ID ${url}`)
+                return null;
+            }
 
-    console.log(filename);
-    const keyPath = getKeyPath(filename);
+            // const iframe = await page.waitForSelector(`#iframe-${id}`);
+            await page.waitForSelector(`.bmpui-image`);
+            const filename = await generateFileName(page);
 
-    if (await fileExists(keyPath)) {
-        await page.close();
-        console.log('information already gathered');
-        return JSON.parse(fs.readFileSync(keyPath, 'utf8'));
-    }
-    const mpdPromise = page.waitForResponse((response) => {
-        if (response.url().endsWith('.mpd')) {
-            return response;
+            console.log(`${filename} - ${url}`);
+            const keyPath = getKeyPath(filename);
+
+            if (await fileExists(keyPath)) {
+                await page.close();
+                console.log('information already gathered');
+                return JSON.parse(fs.readFileSync(keyPath, 'utf8'));
+            }
+
+            const mpdPromise = page.waitForResponse((response) => {
+                if (response.url().endsWith('.mpd')) {
+                    return response;
+                }
+            });
+
+            // wait for post request that ends with 'stream-link'
+            const streamResponsePromise = page.waitForResponse((response) => {
+                if (response.url().endsWith('stream-link') && response.request().method() === 'POST') {
+                    return response;
+                }
+            });
+            
+            // reload the page to get the stream link
+            await page.reload();
+            const streamData = await (await streamResponsePromise).json();
+
+            let x_custom_data = "";
+            try {
+                x_custom_data = streamData['stream']['drmToken'] || "";
+            } catch(TypeError) {
+                const pageContent = await page.content();
+                if(pageContent.includes("Alleen te zien met NPO Plus")) {
+                    console.log('Error content needs NPO Plus subscription');
+                    return null;
+                }
+            }
+
+            const mpdData = parser.parse(await (await mpdPromise).text());
+
+            let pssh = "";
+            // check if the mpdData contains the necessary information
+            if ('ContentProtection' in mpdData["MPD"]["Period"]["AdaptationSet"][1]) {
+                pssh = mpdData["MPD"]["Period"]["AdaptationSet"][1]["ContentProtection"][3].pssh || "";
+            }
+
+            const information = {
+                "filename": filename,
+                "pssh": pssh,
+                "x_custom_data": x_custom_data,
+                "mpdUrl": streamData['stream']['streamURL'],
+                "wideVineKeyResponse": null
+            };
+
+            //if pssh and x_custom_data are not empty, get the keys
+            if (pssh.length !== 0 && x_custom_data.length !== 0) {
+                information.wideVineKeyResponse = ((await getWVKeys(pssh, x_custom_data)).trim());
+            } else {
+                console.log('probably no drm');
+            }
+
+            await writeFile(keyPath, JSON.stringify(information));
+            
+            page.close();
+            console.log(information);
+            return information;
+        } catch(e) {
+            console.log(`Error retrieving information, try ${tries}/3 (${url})`);
+            console.log(e);
+            await sleep(5000);
+            try{
+                await page.close();
+            } catch(E){}
         }
-    });
-
-    // wait for post request that ends with 'stream-link'
-    const streamResponsePromise = page.waitForResponse((response) => {
-        if (response.url().endsWith('stream-link') && response.request().method() === 'POST') {
-            return response;
-        }
-    });
-    // reload the page to get the stream link
-    const streamData = await (await streamResponsePromise).json();
-    const x_custom_data = streamData['stream']['drmToken'] || "";
-
-    const mpdData = parser.parse(await (await mpdPromise).text());
-
-    let pssh = "";
-    // check if the mpdData contains the necessary information
-    if ('ContentProtection' in mpdData["MPD"]["Period"]["AdaptationSet"][1]) {
-        pssh = mpdData["MPD"]["Period"]["AdaptationSet"][1]["ContentProtection"][3].pssh || "";
     }
-
-    const information = {
-        "filename": filename,
-        "pssh": pssh,
-        "x_custom_data": x_custom_data,
-        "mpdUrl": streamData['stream']['streamURL'],
-        "wideVineKeyResponse": null
-    };
-
-    //if pssh and x_custom_data are not empty, get the keys
-    if (pssh.length !== 0 && x_custom_data.length !== 0) {
-        information.wideVineKeyResponse = ((await getWVKeys(pssh, x_custom_data)).trim());
-    } else {
-        console.log('probably no drm');
-    }
-
-    console.log(information);
-
-    await writeFile(keyPath, JSON.stringify(information));
-
-    return information;
 }
 
 function getKeyPath(filename) {
@@ -221,6 +346,10 @@ async function deleteFile(path) {
 
 
 async function downloadFromID(information) {
+    if(information === null) {
+        return null;
+    }
+    
     let filename = information.filename.toString();
 
     console.log(filename);
@@ -334,7 +463,7 @@ function getWVKeys(pssh, x_custom_data) {
 
 async function generateFileName(page) {
     const rawSerie = page.$eval('.font-bold.font-npo-scandia.leading-130.text-30 .line-clamp-2', el => el["innerText"]);
-    const rawTitle = page.$eval('.font-bold.font-npo-scandia.leading-130.text-22', el => el["innerText"]);
+    const rawTitle = page.$eval('h2.font-bold.font-npo-scandia.leading-130.text-22', el => el["innerText"]);
     const rawNumber = page.$eval('.mb-24 .flex.items-center .leading-130.text-13 .line-clamp-1', el => el["innerText"]);
     const rawSeason = page.$eval('.bg-card-3.font-bold.font-npo-scandia.inline-flex.items-center', el => el["innerText"]);
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,11 @@ winget install yt-dlp
 sudo apt install ffmpeg
 sudo apt install yt-dlp
 ```
-
+### for macos
+```bash
+brew install ffmpeg
+brew install yt-dlp
+```
 
 
 ## the following environment variables are required


### PR DESCRIPTION
Cool project. I was not able to run it out of the box on my Windows and macOS machines so I made some changes.

I've made some bugfixes and introducted 2 new functions (getAllEpisodesFromShow and getAllEpisodesFromSeason) to retrieve all episodes of a show in a quick way.

`getAllEpisodesFromShow` - downloads all episodes from all seasons in 1 go. Max amount and starting point can be set.
`getAllEpisodesFromSeason` - download all episodes from a single season in 1 go.

The fixes;
- Added a catch on `TimeoutError` on `waitForNetworkIdle`, since this is not always triggered (on my Windows machine)
- Added a little sleep on the login page since the button was sometimes clicked too fast and did not login
- Added a few checks/catches to prevent errors (like wrong episode ids, or npoplus only content without subscription)
- Fixed correctly getting the episode title on some shows (In some cases a other element with the same class got retrieved)
- Added catches to the getInformation function to prevent crashes on a single failure, and allows 3 tries per episode (some episodes would not download in the first try)
- Added a page reload near the `streamResponsePromise` to make sure all requests are correctly loaded
- Added the videos and json key files to the `gitignore` to prevent pushing these to the public repo
- Added brew install instructions to the readme for macOS

Hope it can help you & others using this project further.